### PR TITLE
Naive implementation for getting all states of a selection

### DIFF
--- a/Editor/plugins/StateDetector.js
+++ b/Editor/plugins/StateDetector.js
@@ -67,27 +67,49 @@
         return commandConfig.acceptsParams ? getValue(selectedNodes, commandOptions) : isApplied(selectedNodes, commandOptions);
     };
 
+    var getSelectedNodesState = function(selectedNodes, commandName) {
+        if (commandName)
+        {
+            return getState(selectedNodes, commandName);
+        }
+        else
+        {
+            var result = {};
+            $.each($.Arte.configuration.commands, function(name, config)
+            {
+                if ($.isPlainObject(config) && config.commandType && config.commandType != constants.commandType.other)
+                {
+                    result[name] = getState(selectedNodes, name);
+                }
+            });
+            return result;
+        }
+    };
+
     // Extend the prototype of the TextArea to expose the public API
     $.extend($.Arte.TextArea.prototype, {
         getState: function(commandName)
         {
             var selectedNodes = $.Arte.util.getSelectedTextNodes.apply(this, [true]);
-            if (commandName)
-            {
-                return getState(selectedNodes, commandName);
-            }
-            else
-            {
-                var result = {};
-                $.each($.Arte.configuration.commands, function(name, config)
-                {
-                    if ($.isPlainObject(config) && config.commandType && config.commandType != constants.commandType.other)
-                    {
-                        result[name] = getState(selectedNodes, name);
-                    }
-                });
-                return result;
-            }
+            return getSelectedNodesState(selectedNodes, commandName);
+        },
+        
+        /**
+        * Get an array of all the states found within the current selection
+        * (ie: if the current selection has both a bold and a non-bold component, get two results representing that)
+        * @param {commandName} string. Optional. If provided, only result the state of the given command (ie: fontFamily, bold, etc)
+        */
+        getAllStates: function(commandName)
+        {
+            var selectedNodes = $.Arte.util.getSelectedTextNodes.apply(this, [true]);
+            var results = [];
+
+            $.each(selectedNodes, function() {
+                var selectedNode = $(this);
+                results.push(getSelectedNodesState(selectedNode, commandName));
+            });
+
+            return results;
         }
     });
 

--- a/Editor/unittests/plugins/StateDetector.UnitTests.js
+++ b/Editor/unittests/plugins/StateDetector.UnitTests.js
@@ -114,5 +114,61 @@ var valueStateDetectorTestData = [
             return result;
         }
 
+    },
+    {
+        name: "getMultiState",
+        rawContent: "<span id='span' style='font-family: arial'>data</span>",
+        elementId: 'span',
+        operation: function(arte)
+        {           
+            $.Arte.dom.cleanup(arte.$el);
+            return arte.getAllStates("fontFamily");
+        },
+        evaluateResult: function(result)
+        {
+            return result[0] === 'arial';
+        }
+    },
+    {
+        name: "getAllSelectionStatesForSpecificProperty",
+        rawContent: "<div id='div'><span style='font-family: arial'>data</span><span style='font-family: courier'>data</span></div>",
+        elementId: 'div',
+        operation: function(arte)
+        {
+            $.Arte.dom.cleanup(arte.$el);
+            return arte.getAllStates("fontFamily");
+        },
+        evaluateResult: function(result)
+        {
+            return result.length === 2 && result[0] === 'arial' && result[1] === 'courier';
+        }
+    },
+    {
+        name: "getAllSelectionStatesValues",
+        rawContent: "<div id='div'><b><span>data</span></b><span>data</span></div>",
+        elementId: 'div',
+        operation: function(arte)
+        {
+            $.Arte.dom.cleanup(arte.$el);
+            return arte.getAllStates("bold");
+        },
+        evaluateResult: function(result)
+        {
+            return result.length === 2 && result[0] && !result[1];
+        }
+    },
+    {
+        name: "getMultiStateAllProperties",
+        rawContent: "<div id='div'><b><span style='font-family: arial'>data</span></b><span style='font-family: courier'>data</span></div>",
+        elementId: 'div',
+        operation: function(arte)
+        {
+            $.Arte.dom.cleanup(arte.$el);
+            return arte.getAllStates();
+        },
+        evaluateResult: function(result)
+        {
+            return result.length === 2 && result[0].fontFamily === 'arial' && result[0].bold && result[1].fontFamily === "courier" && !result[1].bold;
+        }
     }
 ];


### PR DESCRIPTION
Added a method to the state detector to allow getting all of the states of a selection. This is useful when we want to disable buttons based on the state (ie: bold being unavailable for certain fonts) and need to know what is being used in the selection.
