### PR TITLE
fix `npm test` script, make `grunt verify` task viable on its own.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,10 +157,9 @@ module.exports = function (grunt) {
 
     // Default task.
     grunt.registerTask('default', ['build']);
-    grunt.registerTask('travis', ['build']);
-    grunt.registerTask('verify', ['jshint:jslint', 'connect', 'qunit']);
+    grunt.registerTask('travis', ['verify', 'build']);
+    grunt.registerTask('verify', ['clean', 'jshint:jslint', 'uglify', 'concat', 'connect', 'qunit']);
     grunt.registerTask('analysis', ['plato']);
-    grunt.registerTask('build', ['clean', 'uglify', 'concat', 'verify']);
+    grunt.registerTask('build', ['clean', 'uglify', 'concat']);
     grunt.registerTask('all', ['build', 'analysis']);
-
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "test": "grunt nodeunit"
+    "test": "grunt verify"
   },
   "dependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
this changeset also updates the `travis` grunt task to `verify`, then `build`.

this is one approach to fixing #28, I'd love to know what you think.
